### PR TITLE
Make links clickable

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include <QTextDocumentFragment>
 #include <QDebug>
 #include <QDir>
+#include <QRegularExpression>
 
 IrcClient read;
 IrcClient write;
@@ -176,6 +177,22 @@ MainWindow::onMessage(IrcPrivateMessage *message)
 
             offset += replacement.tag.length() - replacement.length;
         }
+    }
+
+    QString url_regex_raw = "((?:https?|ftp)://\\S+)";
+    QRegularExpression url_regex(url_regex_raw, QRegularExpression::CaseInsensitiveOption);
+
+    int offset = 0;
+    while (1){
+        QRegularExpressionMatch match = url_regex.match(html_content, offset);
+        if (!match.hasMatch()) {
+            break;
+        }
+
+        QString url = match.captured(1);
+        QString new_url = "<a href=\"" + url + "\">" + url + "</a>";
+        html_content.replace(match.capturedStart(1), match.capturedLength(1), new_url);
+        offset = match.capturedStart() + new_url.length();
     }
 
     channelChat->insertHtml(html_content);


### PR DESCRIPTION
I can't write regex and had problems with porting the ones I found on the internet. Qt uses some weird perl syntax that I don't want to touch. As a placeholder I used one that only detects `https` (i.e. `https://www.google.com/` ). I'm sure you will be able to make it work like in the pajbot.

Foot note: I decided to use [QRegularExpression](http://doc.qt.io/qt-5/qregularexpression.html) that requires Qt 5.0. I read that it should be better. But if this is a problem then you need to rewrite it to use [QRegExp](http://doc.qt.io/qt-4.8/qregexp.html).
